### PR TITLE
Small fixes

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@dank074/discord-video-stream": "2.1.0",
+                "@dank074/discord-video-stream": "2.1.1",
                 "discord.js-selfbot-v13": "^2.14.9",
                 "puppeteer": "^19.11.1",
                 "puppeteer-stream": "^2.1.4"
@@ -113,9 +113,9 @@
             }
         },
         "node_modules/@dank074/discord-video-stream": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@dank074/discord-video-stream/-/discord-video-stream-2.1.0.tgz",
-            "integrity": "sha512-h0sl5ryeTA1DUK4UIUGx5l47Lwor2v4RcM++ocTTqoRvm/TDuONzt3eGTZ0YGewZMmLtbjBvTrVZs2PNWMNjTg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@dank074/discord-video-stream/-/discord-video-stream-2.1.1.tgz",
+            "integrity": "sha512-SQKAAzj3BB3zimnIGXWHeil986CjJ2+hiJsuISS2Nc1ZZORuCjPfmd0tNZx6ByOv3RctL16I14U1zjANHAOmsQ==",
             "dependencies": {
                 "@dank074/fluent-ffmpeg-multistream-ts": "^1.0.2",
                 "@discordjs/opus": "^0.8.0",
@@ -1862,9 +1862,9 @@
             }
         },
         "@dank074/discord-video-stream": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@dank074/discord-video-stream/-/discord-video-stream-2.1.0.tgz",
-            "integrity": "sha512-h0sl5ryeTA1DUK4UIUGx5l47Lwor2v4RcM++ocTTqoRvm/TDuONzt3eGTZ0YGewZMmLtbjBvTrVZs2PNWMNjTg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@dank074/discord-video-stream/-/discord-video-stream-2.1.1.tgz",
+            "integrity": "sha512-SQKAAzj3BB3zimnIGXWHeil986CjJ2+hiJsuISS2Nc1ZZORuCjPfmd0tNZx6ByOv3RctL16I14U1zjANHAOmsQ==",
             "requires": {
                 "@dank074/fluent-ffmpeg-multistream-ts": "^1.0.2",
                 "@discordjs/opus": "^0.8.0",

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {
-        "@dank074/discord-video-stream": "2.1.0",
+        "@dank074/discord-video-stream": "2.1.1",
         "discord.js-selfbot-v13": "^2.14.9",
         "puppeteer": "^19.11.1",
         "puppeteer-stream": "^2.1.4"

--- a/example/src/config.json
+++ b/example/src/config.json
@@ -6,7 +6,7 @@
         "height": 720,
         "fps": 30,
         "bitrateKbps": 1000,
-        "hardware_acc": false,
+        "hardware_acceleration": false,
         "videoCodec": "H264"
     }
 }

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -14,7 +14,7 @@ setStreamOpts({
     height: config.streamOpts.height, 
     fps: config.streamOpts.fps, 
     bitrateKbps: config.streamOpts.bitrateKbps, 
-    hardware_encoding: config.streamOpts.hardware_acc,
+    hardware_acceleration: config.streamOpts.hardware_acceleration,
     video_codec: config.streamOpts.videoCodec === 'H264' ? 'H264' : 'VP8'
 })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dank074/discord-video-stream",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Experiment for making video streaming work for discord selfbots",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/StreamOpts.ts
+++ b/src/client/StreamOpts.ts
@@ -3,7 +3,7 @@ export interface StreamOpts {
     height?: number;
     fps?: number;
     bitrateKbps?: number;
-    hardware_encoding?: boolean;
+    hardware_acceleration?: boolean;
     video_codec?: 'H264' | 'VP8';
 }
 
@@ -12,7 +12,7 @@ export const streamOpts: StreamOpts = {
     height: 720,
     fps: 30,
     bitrateKbps: 1000,
-    hardware_encoding: false,
+    hardware_acceleration: false,
     video_codec: 'H264'
 }
 
@@ -21,6 +21,6 @@ export const setStreamOpts = (opts: StreamOpts) => {
     streamOpts.height = opts.height ?? streamOpts.height;
     streamOpts.fps = opts.fps ?? streamOpts.fps;
     streamOpts.bitrateKbps = opts.bitrateKbps ?? streamOpts.bitrateKbps;
-    streamOpts.hardware_encoding = opts.hardware_encoding ?? streamOpts.hardware_encoding;
+    streamOpts.hardware_acceleration = opts.hardware_acceleration ?? streamOpts.hardware_acceleration;
     streamOpts.video_codec = opts.video_codec ?? streamOpts.video_codec;
 }

--- a/src/media/H264NalSplitter.ts
+++ b/src/media/H264NalSplitter.ts
@@ -97,10 +97,10 @@ export class H264NalSplitter extends Transform {
      * Returns true if nal magic string with specified length was found.
      * Nal magic string is either 001 or 0001 depending on length
      * @param buf 
-     * @param magicLength 
-     * @returns 
+     * @param magicLength either 3 or 4
+     * @returns true if nalu magic string was found
      */
-    findNalByMagicString(buf: Buffer, magicLength: number) {
+    findNalByMagicString(buf: Buffer, magicLength: 3 | 4) {
         let found = false;
 
         if(magicLength === 3) {

--- a/src/media/streamLivestreamVideo.ts
+++ b/src/media/streamLivestreamVideo.ts
@@ -90,7 +90,7 @@ export function streamLivestreamVideo(input: string | Readable, voiceUdp: VoiceU
                 opus.pipe(audioStream, {end: false});
             }
             
-            if(streamOpts.hardware_encoding) command.inputOption('-hwaccel', 'auto');
+            if(streamOpts.hardware_acceleration) command.inputOption('-hwaccel', 'auto');
             
             if(isHttpUrl) {
                 command.inputOption('-headers', 


### PR DESCRIPTION
- improve method for finding emulation prevention bytes
- don't remove emulation prevention bytes from all nal units, just the important ones, to improve performance
- change name for hardware acceleration since it is not "hardware encoding"