### PR TITLE
Use `performance.now()`

### DIFF
--- a/src/media/AudioStream.ts
+++ b/src/media/AudioStream.ts
@@ -17,11 +17,11 @@ class AudioStream extends Writable {
     _write(chunk: any, _: BufferEncoding, callback: (error?: Error | null) => void) {
         this.count++;
         if (!this.startTime)
-            this.startTime = Date.now();
+            this.startTime = performance.now();
 
         this.udp.sendAudioFrame(chunk);
         
-        const next = ((this.count + 1) * this.sleepTime) - (Date.now() - this.startTime);
+        const next = ((this.count + 1) * this.sleepTime) - (performance.now() - this.startTime);
         setTimeout(() => {
             callback();
         }, next);

--- a/src/media/VideoStream.ts
+++ b/src/media/VideoStream.ts
@@ -21,11 +21,11 @@ export class VideoStream extends Writable {
     _write(frame: any, encoding: BufferEncoding, callback: (error?: Error | null) => void) {
         this.count++;
         if (!this.startTime)
-            this.startTime = Date.now();
+            this.startTime = performance.now();
 
         this.udp.sendVideoFrame(frame);
 
-        const next = ( (this.count + 1) * this.sleepTime) - (Date.now() - this.startTime);
+        const next = ( (this.count + 1) * this.sleepTime) - (performance.now() - this.startTime);
 
        setTimeout(() => {
             callback();


### PR DESCRIPTION
`Date.now()` has less precision, and is affected by the system clock. Use `performance.now()` instead.