### PR TITLE
RTCP Sender Report

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/fluent-ffmpeg": "^2.1.21",
     "@types/libsodium-wrappers": "^0.7.10",
     "@types/node": "^18.17.4",
+    "@types/ws": "^8.5.10",
     "typescript": "^4.9.5"
   },
   "peerDependencies": {

--- a/src/client/packet/AudioPacketizer.ts
+++ b/src/client/packet/AudioPacketizer.ts
@@ -23,7 +23,7 @@ export class AudioPacketizer extends BaseMediaPacketizer {
     }
 
     public override onFrameSent(bytesSent: number): void {
-        super.onFrameSent(bytesSent);
+        super.onFrameSent(1, bytesSent);
         this.incrementTimestamp(time_inc);
     }
 }

--- a/src/client/packet/AudioPacketizer.ts
+++ b/src/client/packet/AudioPacketizer.ts
@@ -8,10 +8,10 @@ export class AudioPacketizer extends BaseMediaPacketizer {
         super(connection, 0x78);
     }
 
-    public override sendFrame(frame:any): void {
+    public override async sendFrame(frame:any): Promise<void> {
        const packet = this.createPacket(frame);
        this.mediaUdp.sendPacket(packet);
-       this.onFrameSent();
+       this.onFrameSent(packet.length);
     }
 
     public createPacket(chunk: any): Buffer {
@@ -21,7 +21,8 @@ export class AudioPacketizer extends BaseMediaPacketizer {
         return Buffer.concat([header, this.encryptData(chunk, nonceBuffer), nonceBuffer.subarray(0, 4)]);
     }
 
-    public override onFrameSent(): void {
+    public override onFrameSent(bytesSent: number): void {
+        super.onFrameSent(bytesSent, this.mediaUdp.mediaConnection.ssrc);
         this.incrementTimestamp(time_inc);
     }
 }

--- a/src/client/packet/AudioPacketizer.ts
+++ b/src/client/packet/AudioPacketizer.ts
@@ -8,7 +8,7 @@ export class AudioPacketizer extends BaseMediaPacketizer {
         super(connection, 0x78);
     }
 
-    public override async sendFrame(frame:any): Promise<void> {
+    public override sendFrame(frame:any): void {
        const packet = this.createPacket(frame);
        this.mediaUdp.sendPacket(packet);
        this.onFrameSent(packet.length);

--- a/src/client/packet/AudioPacketizer.ts
+++ b/src/client/packet/AudioPacketizer.ts
@@ -9,9 +9,10 @@ export class AudioPacketizer extends BaseMediaPacketizer {
     }
 
     public override sendFrame(frame:any): void {
-       const packet = this.createPacket(frame);
-       this.mediaUdp.sendPacket(packet);
-       this.onFrameSent(packet.length);
+        super.sendFrame(frame);
+        const packet = this.createPacket(frame);
+        this.mediaUdp.sendPacket(packet);
+        this.onFrameSent(packet.length);
     }
 
     public createPacket(chunk: any): Buffer {

--- a/src/client/packet/AudioPacketizer.ts
+++ b/src/client/packet/AudioPacketizer.ts
@@ -1,11 +1,12 @@
 import { MediaUdp } from "../voice/MediaUdp";
 import { BaseMediaPacketizer } from "./BaseMediaPacketizer";
 
-const time_inc = (48000 / 100) * 2;
+const frame_size = (48000 / 100) * 2;
 
 export class AudioPacketizer extends BaseMediaPacketizer {
     constructor(connection: MediaUdp) {
         super(connection, 0x78);
+        this.srInterval = 5 * 48000 / frame_size; // ~5 seconds
     }
 
     public override sendFrame(frame:any): void {
@@ -24,6 +25,6 @@ export class AudioPacketizer extends BaseMediaPacketizer {
 
     public override onFrameSent(bytesSent: number): void {
         super.onFrameSent(1, bytesSent);
-        this.incrementTimestamp(time_inc);
+        this.incrementTimestamp(frame_size);
     }
 }

--- a/src/client/packet/AudioPacketizer.ts
+++ b/src/client/packet/AudioPacketizer.ts
@@ -16,14 +16,14 @@ export class AudioPacketizer extends BaseMediaPacketizer {
     }
 
     public createPacket(chunk: any): Buffer {
-        const header = this.makeRtpHeader(this.mediaUdp.mediaConnection.ssrc);
+        const header = this.makeRtpHeader();
 
         const nonceBuffer = this.mediaUdp.getNewNonceBuffer();
         return Buffer.concat([header, this.encryptData(chunk, nonceBuffer), nonceBuffer.subarray(0, 4)]);
     }
 
     public override onFrameSent(bytesSent: number): void {
-        super.onFrameSent(bytesSent, this.mediaUdp.mediaConnection.ssrc);
+        super.onFrameSent(bytesSent);
         this.incrementTimestamp(time_inc);
     }
 }

--- a/src/client/packet/BaseMediaPacketizer.ts
+++ b/src/client/packet/BaseMediaPacketizer.ts
@@ -139,7 +139,7 @@ export class BaseMediaPacketizer {
 
         // Convert from floating point to 32.32 fixed point
         // Convert each part separately to reduce precision loss
-        const ntpTimestamp = this._lastPacketTime - ntpEpoch;
+        const ntpTimestamp = (this._lastPacketTime - ntpEpoch) / 1000;
         const ntpTimestampMsw = Math.floor(ntpTimestamp);
         const ntpTimestampLsw = Math.round((ntpTimestamp - ntpTimestampMsw) * max_int32bit);
 

--- a/src/client/packet/BaseMediaPacketizer.ts
+++ b/src/client/packet/BaseMediaPacketizer.ts
@@ -1,8 +1,8 @@
 import { crypto_secretbox_easy } from "libsodium-wrappers";
 import { MediaUdp } from "../voice/MediaUdp";
 
-export const max_int16bit = (2 ** 16) - 1;
-export const max_int32bit = (2 ** 32) - 1;
+export const max_int16bit = 2 ** 16;
+export const max_int32bit = 2 ** 32;
 
 export class BaseMediaPacketizer {
     private _payloadType: number;
@@ -18,7 +18,7 @@ export class BaseMediaPacketizer {
         this._sequence = 0;
         this._timestamp = 0;
         this._mtu = 1200;
-        this._extensionEnabled = extensionEnabled;;
+        this._extensionEnabled = extensionEnabled;
     }
 
     public sendFrame(frame:any): void {
@@ -51,14 +51,12 @@ export class BaseMediaPacketizer {
     }
 
     public getNewSequence(): number {
-        this._sequence++;
-        if (this._sequence > max_int16bit) this._sequence = 0;
+        this._sequence = (this._sequence + 1) % max_int16bit;
         return this._sequence;
     }
 
     public incrementTimestamp(incrementBy: number): void {
-       this._timestamp += incrementBy;
-        if (this._timestamp > max_int32bit) this._timestamp = 0;
+        this._timestamp = (this._timestamp + incrementBy) % max_int32bit;
     }
 
     public makeRtpHeader(ssrc: number, isLastPacket: boolean = true): Buffer {

--- a/src/client/packet/BaseMediaPacketizer.ts
+++ b/src/client/packet/BaseMediaPacketizer.ts
@@ -48,8 +48,8 @@ export class BaseMediaPacketizer {
         this._lastPacketTime = Date.now();
     }
 
-    public onFrameSent(bytesSent: number): void {
-        this._totalPackets++;
+    public onFrameSent(packetsSent: number, bytesSent: number): void {
+        this._totalPackets = this._totalPackets + packetsSent;
         this._totalBytes = (this._totalBytes + bytesSent) % max_int32bit;
 
         // Send a RTCP Sender Report every 2^7 packets

--- a/src/client/packet/BaseMediaPacketizer.ts
+++ b/src/client/packet/BaseMediaPacketizer.ts
@@ -132,7 +132,7 @@ export class BaseMediaPacketizer {
         senderReport.writeUInt32BE(ntpTimestampMsw, 0);
         senderReport.writeUInt32BE(ntpTimestampLsw, 4);
         senderReport.writeUInt32BE(this._timestamp, 8);
-        senderReport.writeUInt32BE(this._totalPackets, 12);
+        senderReport.writeUInt32BE(this._totalPackets % max_int32bit, 12);
         senderReport.writeUInt32BE(this._totalBytes, 16);
 
         const nonceBuffer = this._mediaUdp.getNewNonceBuffer();

--- a/src/client/packet/BaseMediaPacketizer.ts
+++ b/src/client/packet/BaseMediaPacketizer.ts
@@ -51,8 +51,8 @@ export class BaseMediaPacketizer {
     }
 
     public getNewSequence(): number {
-        this._sequence = (this._sequence + 1) % max_int16bit;
-        return this._sequence;
+        this._sequence = (this._sequence + 1) % max_int32bit;
+        return this._sequence % max_int16bit;
     }
 
     public incrementTimestamp(incrementBy: number): void {

--- a/src/client/packet/BaseMediaPacketizer.ts
+++ b/src/client/packet/BaseMediaPacketizer.ts
@@ -113,9 +113,13 @@ export class BaseMediaPacketizer {
         const senderReport = Buffer.allocUnsafe(20);
 
         // Convert from floating point to 32.32 fixed point
-        const ntpTimestamp = Math.round((this._lastPacketTime - ntpEpoch) / 1000 * 2 ** 32);
+        // Convert each part separately to reduce precision loss
+        const ntpTimestamp = this._lastPacketTime - ntpEpoch;
+        const ntpTimestampMsw = Math.floor(ntpTimestamp);
+        const ntpTimestampLsw = Math.round((ntpTimestamp - ntpTimestampMsw) * max_int32bit);
 
-        senderReport.writeBigUInt64BE(BigInt(ntpTimestamp));
+        senderReport.writeUInt32BE(ntpTimestampMsw, 0);
+        senderReport.writeUInt32BE(ntpTimestampLsw, 4);
         senderReport.writeUInt32BE(this._timestamp, 8);
         senderReport.writeUInt32BE(this._sequence, 12);
         senderReport.writeUInt32BE(this._totalBytes, 16);

--- a/src/client/packet/BaseMediaPacketizer.ts
+++ b/src/client/packet/BaseMediaPacketizer.ts
@@ -13,6 +13,7 @@ export class BaseMediaPacketizer {
     private _timestamp: number;
     private _totalBytes: number;
     private _prevTotalPackets: number;
+    private _lastPacketTime: number;
     private _mediaUdp: MediaUdp;
     private _extensionEnabled: boolean;
 
@@ -29,6 +30,7 @@ export class BaseMediaPacketizer {
 
     public sendFrame(frame:any): void {
         // override this
+        this._lastPacketTime = Date.now();
     }
 
     public onFrameSent(bytesSent: number, ssrc: number): void {
@@ -111,7 +113,7 @@ export class BaseMediaPacketizer {
         const senderReport = Buffer.allocUnsafe(20);
 
         // Convert from floating point to 32.32 fixed point
-        const ntpTimestamp = Math.round((Date.now() - ntpEpoch) / 1000 * 2 ** 32);
+        const ntpTimestamp = Math.round((this._lastPacketTime - ntpEpoch) / 1000 * 2 ** 32);
 
         senderReport.writeBigUInt64BE(BigInt(ntpTimestamp));
         senderReport.writeUInt32BE(this._timestamp, 8);

--- a/src/client/packet/BaseMediaPacketizer.ts
+++ b/src/client/packet/BaseMediaPacketizer.ts
@@ -71,7 +71,7 @@ export class BaseMediaPacketizer {
         this._totalBytes = (this._totalBytes + bytesSent) % max_int32bit;
 
         // Not using modulo here, since the number of packet sent might not be
-        // exactly a multiple of 2^7
+        // exactly a multiple of the interval
         if (Math.floor(this._totalPackets / this._srInterval) - Math.floor(this._prevTotalPackets / this._srInterval) > 0)
         {
             const senderReport = this.makeRtcpSenderReport();

--- a/src/client/packet/BaseMediaPacketizer.ts
+++ b/src/client/packet/BaseMediaPacketizer.ts
@@ -40,7 +40,7 @@ export class BaseMediaPacketizer {
             packetCount += max_int32bit;
         
         // Send a RTCP Sender Report every 2^7 packets
-        // Number chosen is completely arbitrary, but it's close to the interval Discord uses
+        // Number chosen is completely arbitrary
         const interval = 2 ** 7;
 
         // Not using modulo here, since the number of packet sent might not be

--- a/src/client/packet/VideoPacketizerH264.ts
+++ b/src/client/packet/VideoPacketizerH264.ts
@@ -80,10 +80,7 @@ export class VideoPacketizerH264 extends BaseMediaPacketizer {
             const isLastNal = index === nalus.length - 1;
             if (nalu.length <= this.mtu) {
                 // Send as Single-Time Aggregation Packet (STAP-A).
-                const packetHeader = this.makeRtpHeader(
-                    this.mediaUdp.mediaConnection.videoSsrc,
-                    isLastNal
-                );
+                const packetHeader = this.makeRtpHeader(isLastNal);
                 const packetData = Buffer.concat([
                     this.createHeaderExtension(),
                     nalu,
@@ -107,10 +104,7 @@ export class VideoPacketizerH264 extends BaseMediaPacketizer {
 
                     const markerBit = isLastNal && isFinalPacket;
 
-                    const packetHeader = this.makeRtpHeader(
-                        this.mediaUdp.mediaConnection.videoSsrc,
-                        markerBit
-                    );
+                    const packetHeader = this.makeRtpHeader(markerBit);
 
                     const packetData = this.makeChunk(
                         data[i],
@@ -189,7 +183,7 @@ export class VideoPacketizerH264 extends BaseMediaPacketizer {
     }
 
     public override onFrameSent(bytesSent: number): void {
-        super.onFrameSent(bytesSent, this.mediaUdp.mediaConnection.videoSsrc);
+        super.onFrameSent(bytesSent);
         // video RTP packet timestamp incremental value = 90,000Hz / fps
         this.incrementTimestamp(90000 / streamOpts.fps);
     }

--- a/src/client/packet/VideoPacketizerH264.ts
+++ b/src/client/packet/VideoPacketizerH264.ts
@@ -51,6 +51,7 @@ import { BaseMediaPacketizer } from "./BaseMediaPacketizer";
 export class VideoPacketizerH264 extends BaseMediaPacketizer {
     constructor(connection: MediaUdp) {
         super(connection, 0x65, true);
+        this.srInterval = 5 * streamOpts.fps * 2; // ~5 seconds, assuming ~2 packets per frame
     }
 
     /**

--- a/src/client/packet/VideoPacketizerH264.ts
+++ b/src/client/packet/VideoPacketizerH264.ts
@@ -51,7 +51,7 @@ import { BaseMediaPacketizer } from "./BaseMediaPacketizer";
 export class VideoPacketizerH264 extends BaseMediaPacketizer {
     constructor(connection: MediaUdp) {
         super(connection, 0x65, true);
-        this.srInterval = 5 * streamOpts.fps * 2; // ~5 seconds, assuming ~2 packets per frame
+        this.srInterval = 5 * streamOpts.fps * 3; // ~5 seconds, assuming ~3 packets per frame
     }
 
     /**

--- a/src/client/packet/VideoPacketizerH264.ts
+++ b/src/client/packet/VideoPacketizerH264.ts
@@ -73,6 +73,7 @@ export class VideoPacketizerH264 extends BaseMediaPacketizer {
             offset += nalu.length;
         }
 
+        let packetsSent = 0;
         let bytesSent = 0;
         let index = 0;
         for (const nalu of nalus) {
@@ -93,6 +94,7 @@ export class VideoPacketizerH264 extends BaseMediaPacketizer {
                     nonceBuffer.subarray(0, 4),
                 ]);
                 this.mediaUdp.sendPacket(packet);
+                packetsSent++;
                 bytesSent += packet.length;
             } else {
                 const data = this.partitionDataMTUSizedChunks(nalu.subarray(1));
@@ -121,13 +123,14 @@ export class VideoPacketizerH264 extends BaseMediaPacketizer {
                         nonceBuffer.subarray(0, 4),
                     ]);
                     this.mediaUdp.sendPacket(packet);
+                    packetsSent++;
                     bytesSent += packet.length;
                 }
             }
             index++;
         }
 
-        this.onFrameSent(bytesSent);
+        this.onFrameSent(packetsSent, bytesSent);
     }
          
     /**
@@ -182,8 +185,8 @@ export class VideoPacketizerH264 extends BaseMediaPacketizer {
         return Buffer.concat([headerExtensionBuf, fuPayloadHeader, frameData]);
     }
 
-    public override onFrameSent(bytesSent: number): void {
-        super.onFrameSent(bytesSent);
+    public override onFrameSent(packetsSent: number, bytesSent: number): void {
+        super.onFrameSent(packetsSent, bytesSent);
         // video RTP packet timestamp incremental value = 90,000Hz / fps
         this.incrementTimestamp(90000 / streamOpts.fps);
     }

--- a/src/client/packet/VideoPacketizerH264.ts
+++ b/src/client/packet/VideoPacketizerH264.ts
@@ -59,6 +59,7 @@ export class VideoPacketizerH264 extends BaseMediaPacketizer {
      * @param frame h264 video frame
      */
     public override sendFrame(frame: Buffer): void {
+        super.sendFrame(frame);
         let accessUnit = frame;
 
         const nalus: Buffer[] = [];

--- a/src/client/packet/VideoPacketizerVP8.ts
+++ b/src/client/packet/VideoPacketizerVP8.ts
@@ -36,7 +36,7 @@ export class VideoPacketizerVP8 extends BaseMediaPacketizer {
     public createPacket(chunk: any, isLastPacket = true, isFirstPacket = true): Buffer {
         if(chunk.length > this.mtu) throw Error('error packetizing video frame: frame is larger than mtu');
 
-        const packetHeader = this.makeRtpHeader(this.mediaUdp.mediaConnection.videoSsrc, isLastPacket);
+        const packetHeader = this.makeRtpHeader(isLastPacket);
 
         const packetData = this.makeChunk(chunk, isFirstPacket);
     
@@ -46,7 +46,7 @@ export class VideoPacketizerVP8 extends BaseMediaPacketizer {
     }
 
     public override onFrameSent(bytesSent: number): void {
-        super.onFrameSent(bytesSent, this.mediaUdp.mediaConnection.videoSsrc);
+        super.onFrameSent(bytesSent);
         // video RTP packet timestamp incremental value = 90,000Hz / fps
         this.incrementTimestamp(90000 / streamOpts.fps);
         this.incrementPictureId();

--- a/src/client/packet/VideoPacketizerVP8.ts
+++ b/src/client/packet/VideoPacketizerVP8.ts
@@ -12,7 +12,7 @@ export class VideoPacketizerVP8 extends BaseMediaPacketizer {
     constructor(connection: MediaUdp) {
         super(connection, 0x65, true);
         this._pictureId = 0;
-        this.srInterval = 5 * streamOpts.fps * 2; // ~5 seconds, assuming ~2 packets per frame
+        this.srInterval = 5 * streamOpts.fps * 3; // ~5 seconds, assuming ~3 packets per frame
     }
 
     private incrementPictureId(): void {

--- a/src/client/packet/VideoPacketizerVP8.ts
+++ b/src/client/packet/VideoPacketizerVP8.ts
@@ -30,7 +30,7 @@ export class VideoPacketizerVP8 extends BaseMediaPacketizer {
             bytesSent += packet.length;
         }
 
-        this.onFrameSent(bytesSent);
+        this.onFrameSent(data.length, bytesSent);
     }
 
     public createPacket(chunk: any, isLastPacket = true, isFirstPacket = true): Buffer {
@@ -45,8 +45,8 @@ export class VideoPacketizerVP8 extends BaseMediaPacketizer {
         return Buffer.concat([packetHeader, this.encryptData(packetData, nonceBuffer), nonceBuffer.subarray(0, 4)]);
     }
 
-    public override onFrameSent(bytesSent: number): void {
-        super.onFrameSent(bytesSent);
+    public override onFrameSent(packetsSent: number, bytesSent: number): void {
+        super.onFrameSent(packetsSent, bytesSent);
         // video RTP packet timestamp incremental value = 90,000Hz / fps
         this.incrementTimestamp(90000 / streamOpts.fps);
         this.incrementPictureId();

--- a/src/client/packet/VideoPacketizerVP8.ts
+++ b/src/client/packet/VideoPacketizerVP8.ts
@@ -15,8 +15,7 @@ export class VideoPacketizerVP8 extends BaseMediaPacketizer {
     }
 
     private incrementPictureId(): void {
-        this._pictureId++;
-        if(this._pictureId > max_int16bit) this._pictureId = 0;
+        this._pictureId = (this._pictureId + 1) % max_int16bit;
     }
 
     public override sendFrame(frame: any): void {

--- a/src/client/packet/VideoPacketizerVP8.ts
+++ b/src/client/packet/VideoPacketizerVP8.ts
@@ -19,6 +19,7 @@ export class VideoPacketizerVP8 extends BaseMediaPacketizer {
     }
 
     public override sendFrame(frame: any): void {
+        super.sendFrame(frame);
         const data = this.partitionDataMTUSizedChunks(frame);
 
         let bytesSent = 0;

--- a/src/client/packet/VideoPacketizerVP8.ts
+++ b/src/client/packet/VideoPacketizerVP8.ts
@@ -12,6 +12,7 @@ export class VideoPacketizerVP8 extends BaseMediaPacketizer {
     constructor(connection: MediaUdp) {
         super(connection, 0x65, true);
         this._pictureId = 0;
+        this.srInterval = 5 * streamOpts.fps * 2; // ~5 seconds, assuming ~2 packets per frame
     }
 
     private incrementPictureId(): void {

--- a/src/client/voice/BaseMediaConnection.ts
+++ b/src/client/voice/BaseMediaConnection.ts
@@ -122,6 +122,9 @@ export abstract class BaseMediaConnection {
         this.modes = d.modes;
         this.videoSsrc = this.ssrc + 1; // todo: set it from packet streams object
         this.rtxSsrc = this.ssrc + 2;
+
+        this.udp.audioPacketizer.ssrc = this.ssrc;
+        this.udp.videoPacketizer.ssrc = this.videoSsrc;
     }
 
     handleSession(d: any): void {

--- a/src/client/voice/MediaUdp.ts
+++ b/src/client/voice/MediaUdp.ts
@@ -42,8 +42,7 @@ export class MediaUdp {
 
     public getNewNonceBuffer(): Buffer {
         const nonceBuffer = Buffer.alloc(24)
-        this._nonce++;
-        if (this._nonce > max_int32bit) this._nonce = 0;
+        this._nonce = (this._nonce + 1) % max_int32bit;
         
         nonceBuffer.writeUInt32BE(this._nonce, 0);
         return nonceBuffer;


### PR DESCRIPTION
This is still very WIP, missing a few pieces and having some problems that I haven't root caused yet. However it's in a good enough state that other people can test and improve on.

Note: The current implementation timestamps the packet when `sendFrame()` is called. If there are extra processing steps before it that causes the audio and video streams to go out of sync, this will not fix it.

TODO:

- [x] Allow to change the packet interval
- [x] Handle SSRC changes
- When the SSRC is changed, the total packet count and total octet count should be reset
- Does the SSRC actually change in the middle of a stream?
- [x] Add local SSRC variable to `BaseMediaPacketizer`
- Since we're using the SSRC in 2 places now, there should be a local SSRC variable in `BaseMediaPacketizer` to prevent "prop drilling"
- [ ] Troubleshoot "Unknown (-1)" audio codec
- After some amount of time, Discord decided to just stop receiving/decoding audio. The audio codec field in the RTC Debug dialog shows "Unknown (-1)", and all the other stats shows 0
![image](https://github.com/dank074/Discord-video-stream/assets/15729831/f6893284-71d6-477a-a556-09c4e1e0132a)
- Doesn't happen with other watchers. Is it client specific? Do client mods affect it? (I'm using Vencord)
- Haven't tested without the RTCP code yet
- [x] ~Figure out the meaning of the remaining 12 bytes~ They are [RTCP Source Description](https://datatracker.ietf.org/doc/html/rfc3550#section-6.5) packets, so can be left out