### PR TITLE
Optimize `H264NalSplitter` more

### DIFF
--- a/src/media/H264NalSplitter.ts
+++ b/src/media/H264NalSplitter.ts
@@ -113,17 +113,14 @@ export class H264NalSplitter extends Transform {
             chunk = chunk.subarray(nalStart.index + nalStart.length);
             this._buffer = emptyBuffer;
         }
+        chunk = Buffer.concat([this._buffer, chunk]);
         while (nalStart = this.findNalStart(chunk))
         {
-            const frame = Buffer.concat([
-                this._buffer,
-                chunk.subarray(0, nalStart.index)
-            ]);
+            const frame = chunk.subarray(0, nalStart.index);
             this.processFrame(frame);
             chunk = chunk.subarray(nalStart.index + nalStart.length);
-            this._buffer = emptyBuffer;
         }
-        this._buffer = Buffer.concat([this._buffer, chunk]);
+        this._buffer = chunk;
         callback();
     }
 }

--- a/src/media/H264NalSplitter.ts
+++ b/src/media/H264NalSplitter.ts
@@ -77,7 +77,7 @@ export class H264NalSplitter extends Transform {
                 this._accessUnit.forEach(nalu => sizeOfAccessUnit += nalu.length);
 
                 // total length is sum of all nalu lengths, plus 4 bytes for each nalu
-                const accessUnitBuf = Buffer.alloc(sizeOfAccessUnit + (4 * this._accessUnit.length));
+                const accessUnitBuf = Buffer.allocUnsafe(sizeOfAccessUnit + (4 * this._accessUnit.length));
 
                 let offset = 0;
                 for (let nalu of this._accessUnit) {

--- a/src/media/H264NalSplitter.ts
+++ b/src/media/H264NalSplitter.ts
@@ -73,11 +73,9 @@ export class H264NalSplitter extends Transform {
 
         if (unitType === NalUnitTypes.AccessUnitDelimiter) {
             if (this._accessUnit.length > 0) {
-                let sizeOfAccessUnit = 0;
-                this._accessUnit.forEach(nalu => sizeOfAccessUnit += nalu.length);
-
                 // total length is sum of all nalu lengths, plus 4 bytes for each nalu
-                const accessUnitBuf = Buffer.allocUnsafe(sizeOfAccessUnit + (4 * this._accessUnit.length));
+                let sizeOfAccessUnit = this._accessUnit.reduce((acc, nalu) => acc + nalu.length + 4, 0);
+                const accessUnitBuf = Buffer.allocUnsafe(sizeOfAccessUnit);
 
                 let offset = 0;
                 for (let nalu of this._accessUnit) {


### PR DESCRIPTION
This is probably stepping into the realm of micro-optimizations, and only matters to the slowest of computers, but I'll take any opportunity to optimize :)

I forgot to commit the changes separately, so the first commit is a bit huge, but here's a rundown of all the changes
- Rewritten `rbsp` to use `indexOf` and `copy`
- A better way to search for NAL start codes that only uses 1 `indexOf` call
- Rewritten chunking loop to only scan each data chunk exactly once