### PR TITLE
Allow disabling sleep in process streams

### DIFF
--- a/src/media/AudioStream.ts
+++ b/src/media/AudioStream.ts
@@ -6,12 +6,14 @@ class AudioStream extends Writable {
     public count: number;
     public sleepTime: number;
     public startTime?: number;
-    
-    constructor(udp: MediaUdp) {
+    private noSleep: boolean;
+
+    constructor(udp: MediaUdp, noSleep = false) {
         super();
         this.udp = udp;
         this.count = 0;
         this.sleepTime = 20;
+        this.noSleep = noSleep;
     }
 
     _write(chunk: any, _: BufferEncoding, callback: (error?: Error | null) => void) {
@@ -22,9 +24,17 @@ class AudioStream extends Writable {
         this.udp.sendAudioFrame(chunk);
         
         const next = ((this.count + 1) * this.sleepTime) - (performance.now() - this.startTime);
-        setTimeout(() => {
+
+        if (this.noSleep)
+        {
             callback();
-        }, next);
+        }
+        else
+        {
+            setTimeout(() => {
+                callback();
+            }, next);
+        }
     }
 }
 

--- a/src/media/VideoStream.ts
+++ b/src/media/VideoStream.ts
@@ -6,12 +6,14 @@ export class VideoStream extends Writable {
     public count: number;
     public sleepTime: number;
     public startTime?: number;
-    
-    constructor(udp: MediaUdp, fps: number = 30) {
+    private noSleep: boolean;
+
+    constructor(udp: MediaUdp, fps: number = 30, noSleep = false) {
         super();
         this.udp = udp;
         this.count = 0;
         this.sleepTime = 1000 / fps;
+        this.noSleep = noSleep;
     }
 
     public setSleepTime(time: number) {
@@ -27,8 +29,15 @@ export class VideoStream extends Writable {
 
         const next = ( (this.count + 1) * this.sleepTime) - (performance.now() - this.startTime);
 
-       setTimeout(() => {
+        if (this.noSleep)
+        {
             callback();
-        }, next);
+        }
+        else
+        {
+            setTimeout(() => {
+                callback();
+            }, next);
+        }
     }
 }


### PR DESCRIPTION
For true real-time sources (RTSP/RTMP/SRT livestreams), sleeping is not recommended, since it prevents ffmpeg from "catching up" with the livestream, and can cause packet loss from the input side if a UDP-based protocol is used.

This PR adds a parameter to allow disabling the sleeping behavior.