### PR TITLE
Remove the NALU packing hack

### DIFF
--- a/src/client/processing/AnnexBNalSplitter.ts
+++ b/src/client/processing/AnnexBNalSplitter.ts
@@ -76,29 +76,7 @@ class AnnexBNalSplitter extends Transform {
         if (frame.length == 0) return;
 
         const unitType = this._nalFunctions.getUnitType(frame);
-
-        if (this._nalFunctions.isAUD(unitType)) {
-            if (this._accessUnit.length > 0) {
-                // total length is sum of all nalu lengths, plus 4 bytes for each nalu
-                let sizeOfAccessUnit = this._accessUnit.reduce((acc, nalu) => acc + nalu.length + 4, 0);
-                const accessUnitBuf = Buffer.allocUnsafe(sizeOfAccessUnit);
-
-                let offset = 0;
-                for (let nalu of this._accessUnit) {
-                    // hacky way of outputting several nal units that belong to the same access unit
-                    accessUnitBuf.writeUint32BE(nalu.length, offset);
-                    offset += 4;
-                    nalu.copy(accessUnitBuf, offset)
-                    offset += nalu.length;
-                }
-
-                this.push(accessUnitBuf);
-                this._accessUnit = [];
-            }
-        } else {
-            // remove emulation bytes from frame (only importannt ones like SPS and SEI since its costly operation)
-            this._accessUnit.push(this.removeEpbs(frame, unitType));
-        }
+        this.push(this.removeEpbs(frame, unitType));
     }
 
     _transform(chunk: Buffer, encoding: BufferEncoding, callback: TransformCallback): void {


### PR DESCRIPTION
Instead of packing the NAL units into frames before sending to the packetizer, now we send the NAL units itself, including the AUD to the packetizer, and then set the marker bit on the AUD instead. This saves an allocation every frame.

With this change, the `sendFrame` function no longer receives individual frames, but individual NAL units instead. We can either do nothing, or rename it into something more appropriate. New naming welcome.