### PR TITLE
Update deps, move `@discordjs/opus` to optional deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,21 +13,24 @@
   },
   "dependencies": {
     "@dank074/fluent-ffmpeg-multistream-ts": "^1.0.2",
-    "@discordjs/opus": "^0.8.0",
     "fluent-ffmpeg": "^2.1.2",
-    "libsodium-wrappers": "^0.7.11",
+    "libsodium-wrappers": "^0.7.13",
+    "opusscript": "^0.1.1",
     "prism-media": "^1.3.5",
-    "ws": "^8.13.0"
+    "ws": "^8.16.0"
   },
   "devDependencies": {
-    "@types/fluent-ffmpeg": "^2.1.21",
-    "@types/libsodium-wrappers": "^0.7.10",
-    "@types/node": "^18.17.4",
+    "@types/fluent-ffmpeg": "^2.1.24",
+    "@types/libsodium-wrappers": "^0.7.14",
+    "@types/node": "^20.12.7",
     "@types/ws": "^8.5.10",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "discord.js-selfbot-v13": "2.x"
+    "discord.js-selfbot-v13": "3.x"
+  },
+  "optionalDependencies": {
+    "@discordjs/opus": "^0.9.0"
   },
   "scripts": {
     "build": "tsc"


### PR DESCRIPTION
Closes #68

Updating `discord.js-selfbot-v13` to `3.x` since TypeScript screams at me non-stop.
Also, due to https://github.com/dank074/Discord-video-stream/issues/58, I've made `@discordjs/opus` an optional dependency, and added `opusscript` as a fallback. That way on machines that fail to build `@discordjs/opus`, there'll be a WASM option available.