### PR TITLE
Use `p-cancelable`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "fluent-ffmpeg": "^2.1.2",
     "libsodium-wrappers": "^0.7.13",
     "opusscript": "^0.1.1",
+    "p-cancelable": "^4.0.1",
     "prism-media": "^1.3.5",
     "ws": "^8.16.0"
   },


### PR DESCRIPTION
This is an implementation of my suggestion in https://github.com/dank074/Discord-video-stream/issues/88#issuecomment-2074024524

Usage:
```javascript
let playback;
try {
    playback = streamLivestreamVideo(...);
    await playback;
}
catch (e)
{
    if (playback.isCanceled)
        // do stuff when cancel
    // do stuff when error
}

// somewhere else
playback?.cancel();
```