### PR TITLE
Bring back sleeping code for periodic frame timing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "debug-level": "^3.2.1",
     "fluent-ffmpeg": "^2.1.3",
     "p-cancelable": "^4.0.1",
+    "p-debounce": "^4.0.0",
     "sodium-plus": "^0.9.0",
     "uid": "^2.0.2",
     "ws": "^8.18.0"

--- a/src/media/AudioStream.ts
+++ b/src/media/AudioStream.ts
@@ -4,8 +4,8 @@ import { BaseMediaStream } from "./BaseMediaStream.js";
 export class AudioStream extends BaseMediaStream {
     public udp: MediaUdp;
 
-    constructor(udp: MediaUdp) {
-        super("audio");
+    constructor(udp: MediaUdp, noSleep: boolean = false) {
+        super("audio", noSleep);
         this.udp = udp;
     }
 

--- a/src/media/VideoStream.ts
+++ b/src/media/VideoStream.ts
@@ -4,8 +4,8 @@ import { BaseMediaStream } from "./BaseMediaStream.js";
 export class VideoStream extends BaseMediaStream {
     public udp: MediaUdp;
 
-    constructor(udp: MediaUdp) {
-        super("video");
+    constructor(udp: MediaUdp, noSleep: boolean = false) {
+        super("video", noSleep);
         this.udp = udp;
     }
 

--- a/src/media/streamLivestreamVideo.ts
+++ b/src/media/streamLivestreamVideo.ts
@@ -106,8 +106,6 @@ export function streamLivestreamVideo(
 
             if (streamOpts.hardwareAcceleratedDecoding) command.inputOption('-hwaccel', 'auto');
 
-            command.inputOption('-re')
-
             if (streamOpts.minimizeLatency) {
                 command.addOptions([
                     '-fflags nobuffer',


### PR DESCRIPTION
Turns out relying on `-re` to provide periodic frame output is wrong, as I learned [the hard way](https://github.com/dank074/Discord-video-stream/issues/115#issuecomment-2493270004). This PR reintroduces the sleeping code for periodic frame output, which also involves getting backpressure to work so that memory leaks don't happen.

The mechanism for this is pretty simple. Frames are repeatedly extracted from the input stream until either the video or audio pipe reaches `highWaterMark`, after which we pause the input stream. When the pipe has been drained, we resume the input stream and continue extraction.

Unfortunately, this only partially fixes #115, something in the video file is causing consistent 5+ seconds pauses, that doesn't happen with other files that I've tested. Will continue to investigate. For now please give this a try.