### PR TITLE
Use ffmpeg provided frametime for RTP timestamp calculation

### DIFF
--- a/src/client/packet/AudioPacketizer.ts
+++ b/src/client/packet/AudioPacketizer.ts
@@ -9,11 +9,11 @@ export class AudioPacketizer extends BaseMediaPacketizer {
         this.srInterval = 5 * 48000 / frame_size; // ~5 seconds
     }
 
-    public override async sendFrame(frame: Buffer): Promise<void> {
-        super.sendFrame(frame);
+    public override async sendFrame(frame: Buffer, frametime: number): Promise<void> {
+        super.sendFrame(frame, frametime);
         const packet = await this.createPacket(frame);
         this.mediaUdp.sendPacket(packet);
-        this.onFrameSent(packet.length);
+        this.onFrameSent(packet.length, frametime);
     }
 
     public async createPacket(chunk: Buffer): Promise<Buffer> {
@@ -23,8 +23,8 @@ export class AudioPacketizer extends BaseMediaPacketizer {
         return Buffer.concat([header, await this.encryptData(chunk, nonceBuffer, header), nonceBuffer.subarray(0, 4)]);
     }
 
-    public override async onFrameSent(bytesSent: number): Promise<void> {
-        await super.onFrameSent(1, bytesSent);
-        this.incrementTimestamp(frame_size);
+    public override async onFrameSent(bytesSent: number, frametime: number): Promise<void> {
+        await super.onFrameSent(1, bytesSent, frametime);
+        this.incrementTimestamp(frametime * (48000 / 1000));
     }
 }

--- a/src/client/packet/AudioPacketizer.ts
+++ b/src/client/packet/AudioPacketizer.ts
@@ -1,12 +1,10 @@
 import { MediaUdp } from "../voice/MediaUdp.js";
 import { BaseMediaPacketizer } from "./BaseMediaPacketizer.js";
 
-const frame_size = (48000 / 100) * 2;
-
 export class AudioPacketizer extends BaseMediaPacketizer {
     constructor(connection: MediaUdp) {
         super(connection, 0x78);
-        this.srInterval = 5 * 48000 / frame_size; // ~5 seconds
+        this.srInterval = 5 * 1000 / 20; // ~5 seconds for 20ms frame time
     }
 
     public override async sendFrame(frame: Buffer, frametime: number): Promise<void> {

--- a/src/client/packet/BaseMediaPacketizer.ts
+++ b/src/client/packet/BaseMediaPacketizer.ts
@@ -69,12 +69,12 @@ export class BaseMediaPacketizer {
         this._srInterval = interval;
     }
 
-    public async sendFrame(frame: Buffer): Promise<void> {
+    public async sendFrame(frame: Buffer, frametime: number): Promise<void> {
         // override this
         this._lastPacketTime = Date.now();
     }
 
-    public async onFrameSent(packetsSent: number, bytesSent: number): Promise<void> {
+    public async onFrameSent(packetsSent: number, bytesSent: number, frametime: number): Promise<void> {
         if(!this._mediaUdp.mediaConnection.streamOptions.rtcpSenderReportEnabled) return;
         
         this._totalPackets = this._totalPackets + packetsSent;

--- a/src/client/packet/VideoPacketizerAnnexB.ts
+++ b/src/client/packet/VideoPacketizerAnnexB.ts
@@ -71,8 +71,8 @@ class VideoPacketizerAnnexB extends BaseMediaPacketizer {
      * MTU-sized chunks
      * @param frame Annex B video frame
      */
-    public override async sendFrame(frame: Buffer): Promise<void> {
-        super.sendFrame(frame);
+    public override async sendFrame(frame: Buffer, frametime: number): Promise<void> {
+        super.sendFrame(frame, frametime);
 
         const nalus = splitNalu(frame);
 
@@ -141,17 +141,17 @@ class VideoPacketizerAnnexB extends BaseMediaPacketizer {
             index++;
         }
 
-        await this.onFrameSent(packetsSent, bytesSent);
+        await this.onFrameSent(packetsSent, bytesSent, frametime);
     }
 
     protected makeFragmentationUnitHeader(isFirstPacket: boolean, isLastPacket: boolean, naluHeader: Buffer): Buffer {
         throw new Error("Not implemented");
     }
 
-    public override async onFrameSent(packetsSent: number, bytesSent: number): Promise<void> {
-        await super.onFrameSent(packetsSent, bytesSent);
+    public override async onFrameSent(packetsSent: number, bytesSent: number, frametime: number): Promise<void> {
+        await super.onFrameSent(packetsSent, bytesSent, frametime);
         // video RTP packet timestamp incremental value = 90,000Hz / fps
-        this.incrementTimestamp(90000 / this.mediaUdp.mediaConnection.streamOptions.fps);
+        this.incrementTimestamp(90000 / 1000 * frametime);
     }
 }
 

--- a/src/client/packet/VideoPacketizerVP8.ts
+++ b/src/client/packet/VideoPacketizerVP8.ts
@@ -19,8 +19,8 @@ export class VideoPacketizerVP8 extends BaseMediaPacketizer {
         this._pictureId = (this._pictureId + 1) % max_int16bit;
     }
 
-    public override async sendFrame(frame: Buffer): Promise<void> {
-        super.sendFrame(frame);
+    public override async sendFrame(frame: Buffer, frametime: number): Promise<void> {
+        super.sendFrame(frame, frametime);
         const data = this.partitionDataMTUSizedChunks(frame);
 
         let bytesSent = 0;
@@ -30,7 +30,7 @@ export class VideoPacketizerVP8 extends BaseMediaPacketizer {
             bytesSent += packet.length;
         }
 
-        await this.onFrameSent(data.length, bytesSent);
+        await this.onFrameSent(data.length, bytesSent, frametime);
     }
 
     public async createPacket(chunk: any, isLastPacket = true, isFirstPacket = true): Promise<Buffer> {
@@ -45,10 +45,10 @@ export class VideoPacketizerVP8 extends BaseMediaPacketizer {
         return Buffer.concat([packetHeader, await this.encryptData(packetData, nonceBuffer, packetHeader), nonceBuffer.subarray(0, 4)]);
     }
 
-    public override async onFrameSent(packetsSent: number, bytesSent: number): Promise<void> {
-        await super.onFrameSent(packetsSent, bytesSent);
+    public override async onFrameSent(packetsSent: number, bytesSent: number, frametime: number): Promise<void> {
+        await super.onFrameSent(packetsSent, bytesSent, frametime);
         // video RTP packet timestamp incremental value = 90,000Hz / fps
-        this.incrementTimestamp(90000 / this.mediaUdp.mediaConnection.streamOptions.fps);
+        this.incrementTimestamp(90000 / 1000 * frametime);
         this.incrementPictureId();
     }
 

--- a/src/client/voice/MediaUdp.ts
+++ b/src/client/voice/MediaUdp.ts
@@ -85,14 +85,14 @@ export class MediaUdp {
         this._encryptionMode = mode;
     }
 
-    public async sendAudioFrame(frame: Buffer): Promise<void> {
+    public async sendAudioFrame(frame: Buffer, frametime: number): Promise<void> {
         if(!this.ready) return;
-        await this.audioPacketizer.sendFrame(frame);
+        await this.audioPacketizer.sendFrame(frame, frametime);
     }
 
-    public async sendVideoFrame(frame: Buffer): Promise<void> {
+    public async sendVideoFrame(frame: Buffer, frametime: number): Promise<void> {
         if(!this.ready) return;
-        await this.videoPacketizer.sendFrame(frame)
+        await this.videoPacketizer.sendFrame(frame, frametime);
     }
 
     public sendPacket(packet: Buffer): Promise<void> {

--- a/src/media/AudioStream.ts
+++ b/src/media/AudioStream.ts
@@ -9,7 +9,7 @@ export class AudioStream extends BaseMediaStream {
         this.udp = udp;
     }
 
-    protected override async _sendFrame(frame: Buffer): Promise<void> {
-        await this.udp.sendAudioFrame(frame);
+    protected override async _sendFrame(frame: Buffer, frametime: number): Promise<void> {
+        await this.udp.sendAudioFrame(frame, frametime);
     }
 }

--- a/src/media/BaseMediaStream.ts
+++ b/src/media/BaseMediaStream.ts
@@ -55,7 +55,7 @@ export class BaseMediaStream extends Writable {
             i = (i + 1) % 10;
         }
     }
-    protected async _sendFrame(_: Buffer): Promise<void>
+    protected async _sendFrame(frame: Buffer, frametime: number): Promise<void>
     {
         throw new Error("Not implemented");
     }
@@ -68,7 +68,7 @@ export class BaseMediaStream extends Writable {
         const frametime = combineLoHi(durationhi!, duration!) / time_base_den! * time_base_num! * 1000;
 
         const start = performance.now();
-        await this._sendFrame(Buffer.from(data));
+        await this._sendFrame(Buffer.from(data), frametime);
         const end = performance.now();
         this._pts = combineLoHi(ptshi!, pts!) / time_base_den! * time_base_num! * 1000;
         if (this._startPts === undefined)

--- a/src/media/VideoStream.ts
+++ b/src/media/VideoStream.ts
@@ -9,7 +9,7 @@ export class VideoStream extends BaseMediaStream {
         this.udp = udp;
     }
 
-    protected override async _sendFrame(frame: Buffer): Promise<void> {
-        await this.udp.sendVideoFrame(frame);
+    protected override async _sendFrame(frame: Buffer, frametime: number): Promise<void> {
+        await this.udp.sendVideoFrame(frame, frametime);
     }
 }


### PR DESCRIPTION
A step towards reducing reliance on user-set variables. This PR allows using ffmpeg reported frame time to increment the RTP timestamp. Should provide better support for fractional frame rate (23.976 and alike) and variable frame rate (not tested by me though)