### PR TITLE
Tweak `highWaterMark`, re-enable LibAV multithreading

### DIFF
--- a/src/media/BaseMediaStream.ts
+++ b/src/media/BaseMediaStream.ts
@@ -17,7 +17,7 @@ export class BaseMediaStream extends Writable {
 
     public syncStream?: BaseMediaStream;
     constructor(type: string, noSleep: boolean = false) {
-        super({ objectMode: true })
+        super({ objectMode: true, highWaterMark: 0 });
         this._loggerSend = new Log(`stream:${type}:send`);
         this._loggerSync = new Log(`stream:${type}:sync`);
         this._loggerSleep = new Log(`stream:${type}:sleep`);


### PR DESCRIPTION
No need to have extra buffering on `BaseMediaStream`, so `highWaterMark` is set to 0 there. I also re-enabled multi-threading after figuring out what went wrong last time.