### PR TITLE
prevent fluent-ffmpeg exception when killing process

### DIFF
--- a/src/media/streamLivestreamVideo.ts
+++ b/src/media/streamLivestreamVideo.ts
@@ -37,7 +37,6 @@ export function streamLivestreamVideo(
         try {
             // command creation
             const command = ffmpeg(input)
-                .output(ffmpegOutput)
                 .addOption('-loglevel', '0')
                 .on('end', () => {
                     resolve("video ended")
@@ -49,6 +48,7 @@ export function streamLivestreamVideo(
 
             // general output options
             command
+                .output(ffmpegOutput)
                 .size(`${streamOpts.width}x${streamOpts.height}`)
                 .fpsOutput(streamOpts.fps)
                 .videoBitrate(`${streamOpts.bitrateKbps}k`)


### PR DESCRIPTION
When killing the ffmpeg process I was getting the following exception:
```
TypeError: Cannot read properties of undefined (reading 'get') at endCB fluent-ffmpeg\lib\processor.js:543:37)
```
It seems to be a fluent-ffmpeg bug: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/issues/861

It stopped throwing the exception when I moved the `.output` line in the ffmpeg command builder after the lines attaching event listeners with `.on`