### PR TITLE
Return a promise on stream finish to improve async handling in playStream function

### DIFF
--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -390,9 +390,12 @@ export async function playStream(
         vStream.syncStream = aStream;
         aStream.syncStream = vStream;
     }
-    vStream.once("finish", () => {
-        stopStream();
-        udp.mediaConnection.setSpeaking(false);
-        udp.mediaConnection.setVideoStatus(false);
+    return new Promise<void>((resolve) => {
+        vStream.once("finish", () => {
+            stopStream();
+            udp.mediaConnection.setSpeaking(false);
+            udp.mediaConnection.setVideoStatus(false);
+            resolve();
+        });
     });
 }


### PR DESCRIPTION
When using `playStream` in a playlist loop, the `vStream.once("finish")` callback in its current implementation does not provide a mechanism to await the completion of a video before proceeding to the next one. As a result, all videos in the playlist attempt to play simultaneously.

* [`src/media/newApi.ts`](diffhunk://#diff-a520dddc64ccaf64af3f7c950f3514931c0413b12fa61a49fc3adbbe5e35751cR393-R399): Added a promise to the `playStream` function that resolves when the stream finishes.

Usage example:
```typescript
const client = new Client();
const streamer = new Streamer(client);
let current: ReturnType<typeof NewApi.prepareStream>["command"];

client.on("ready", async () => {
  console.log("Ready");

  await streamer.joinVoice(config.guildId, config.channelId);
  if (streamer.client.user!.voice!.channel instanceof StageChannel) await streamer.client.user!.voice!.setSuppressed(false);

  const playlist = [
    {
      title: "Video 1",
      url: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
    },
    {
      title: "Video 2",
      url: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
    }
  ]

  for (const video of playlist) {
    await playVideo(video);
  }
});

const playVideo = async (video: { title: string; url: string }) => {
  console.log("Video: ", video);

  try {
    const { command, output } = NewApi.prepareStream(video.url, {
      height: config.streamOpts.height,
      bitrateVideo: config.streamOpts.bitrateKbps,
      bitrateVideoMax: config.streamOpts.maxBitrateKbps,
      hardwareAcceleratedDecoding: true,
      videoCodec: "H264",
      h26xPreset: "fast",
      frameRate: config.streamOpts.fps,
    });

    current = command;

    current.on("end", () => {
      console.log("ffmpeg ended");
    });

    current.on("error", (error) => {
      if (error.message.includes("SIGINT")) {
        streamer.stopStream();
        streamer.voiceConnection.streamConnection?.setSpeaking(false);
        streamer.voiceConnection.streamConnection?.setVideoStatus(false);
      } else console.log("Stream error: ", error);
    });

    await NewApi.playStream(output, streamer);
    current = undefined;
  } catch (error) {
    console.log(error);
  }
};

process.on("SIGINT", () => {
  client.logout();
  client.destroy();
  process.exit();
});

await client.login(config.token);
```