### PR TITLE
Increase audio and video stream buffer size to 128 frames

### DIFF
--- a/src/media/LibavDemuxer.ts
+++ b/src/media/LibavDemuxer.ts
@@ -224,8 +224,8 @@ export async function demux(input: Readable) {
     const aStream = streams.find((stream) => stream.codec_type == libav.AVMEDIA_TYPE_AUDIO)
     let vInfo: VideoStreamInfo | undefined
     let aInfo: AudioStreamInfo | undefined;
-    const vPipe = new PassThrough({ objectMode: true });
-    const aPipe = new PassThrough({ objectMode: true });
+    const vPipe = new PassThrough({ objectMode: true, highWaterMark: 128 });
+    const aPipe = new PassThrough({ objectMode: true, highWaterMark: 128 });
 
     if (vStream) {
         if (!allowedVideoCodec.has(vStream.codec_id)) {


### PR DESCRIPTION
On very bad sources (for example live streams over bad connection), there can be scenarios where one stream is completely full, while the other is completely empty, which causes the full stream to wait forever for the empty stream, which will never receive a frame. I haven't thought of a good solution for this yet, so for now, increase both stream's buffer size to 128 frames.