### PR TITLE
Replace `isIPv4` with `isIP`

### DIFF
--- a/src/client/voice/MediaUdp.ts
+++ b/src/client/voice/MediaUdp.ts
@@ -1,5 +1,5 @@
 import udpCon from 'node:dgram';
-import { isIPv4 } from 'node:net';
+import { isIP } from 'node:net';
 import { AudioPacketizer } from '../packet/AudioPacketizer.js';
 import {
     VideoPacketizerH264,
@@ -16,7 +16,7 @@ function parseLocalPacket(message: Buffer) {
 
 	const ip = packet.subarray(8, packet.indexOf(0, 8)).toString('utf8');
 
-	if (!isIPv4(ip)) {
+	if (!isIP(ip)) {
 		throw new Error('Malformed IP address');
 	}
 


### PR DESCRIPTION
Apparently this IP can be IPv6 now (or to be more precise, an IPv4 mapped IPv6 address with the form `::ffff:aaa.bbb.ccc.ddd`). Just replacing `isIPv4` with `isIP` seems to work fine.