### PR TITLE
media: Adjust zmq endpoint

### DIFF
--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -336,7 +336,7 @@ export function prepareStream(
             return null;
         if (isBun() || isDeno())
             return null;
-        const zmqEndpoint = "tcp://localhost:42069";
+        const zmqEndpoint = "tcp://127.0.0.1:42069";
         command.audioFilters(`azmq=b=${zmqEndpoint.replaceAll(":","\\\\:")}`);
 
         const zmq = await import("zeromq");


### PR DESCRIPTION
Not sure how it works for others, newer libzmq?
https://stackoverflow.com/questions/6024003/why-doesnt-zeromq-work-on-localhost

ffmpeg info:
```
ffmpeg version 7.1.1 Copyright (c) 2000-2025 the FFmpeg developers
  built with gcc 11 (Ubuntu 11.4.0-1ubuntu1~22.04)
  configuration: --disable-decoder=amrnb --disable-gnutls --disable-liblensfun --disable-libopencv --disable-podpages --disable-sndio --disable-stripping --enable-avfilter --enable-chromaprint --enable-frei0r --enable-gcrypt --enable-gpl --enable-ladspa --enable-libaom --enable-libaribb24 --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d --enable-libdc1394 --enable-libdrm --enable-libdvdnav --enable-libdvdread --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libharfbuzz --enable-libiec61883 --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libplacebo --enable-libpulse --enable-librabbitmq --enable-librsvg --enable-librubberband --enable-libshine --enable-libsmbclient --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libtesseract --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvo-amrwbenc --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq --enable-libzvbi --enable-lv2 --enable-nonfree --enable-openal --enable-opencl --enable-opengl --enable-openssl --enable-postproc --enable-pthreads --enable-shared --enable-version3 --incdir=/usr/include/x86_64-linux-gnu --libdir=/usr/lib/x86_64-linux-gnu --prefix=/usr --toolchain=hardened --enable-vaapi --enable-libvpl --enable-libxavs2 --enable-libdavs2 --enable-libvmaf --enable-libvvenc --enable-libilbc --enable-libklvanc --enable-libfdk-aac --enable-libkvazaar --enable-omx --enable-libsvtav1 --enable-librist --enable-libjxl --enable-libopenh264 --cc=x86_64-linux-gnu-gcc --cxx=x86_64-linux-gnu-g++ --disable-altivec --shlibdir=/usr/lib/x86_64-linux-gnu
  libavutil      59. 39.100 / 59. 39.100
  libavcodec     61. 19.101 / 61. 19.101
  libavformat    61.  7.100 / 61.  7.100
  libavdevice    61.  3.100 / 61.  3.100
  libavfilter    10.  4.100 / 10.  4.100
  libswscale      8.  3.100 /  8.  3.100
  libswresample   5.  3.100 /  5.  3.100
  libpostproc    58.  3.100 / 58.  3.100
Universal media converter
usage: ffmpeg [options] [[infile options] -i infile]... {[outfile options] outfile}...
```

error log:
```
VFilterGraph @ 0x64c680128780] Setting 'volume' to value '1.0'
[AVFilterGraph @ 0x64c680128780] Setting 'b' to value 'tcp://localhost:42069'
[Parsed_azmq_1 @ 0x64c680128ac0] Could not bind ZMQ socket to address 'tcp://localhost:42069': No such device
[AVFilterGraph @ 0x64c680128780] Error initializing filters
Error opening output file pipe:1.
Error opening output files: Generic error in an external library
[AVIOContext @ 0x64c67f089600] Statistics: 1060060 bytes read, 2 seeks
``