### PR TITLE
fix: unhandled promise rejection

### DIFF
--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -344,7 +344,7 @@ export function prepareStream(
         receiveTimeout: 5000,
       });
       client.connect(zmqEndpoint);
-      promise.finally(() => client.disconnect(zmqEndpoint));
+      promise.catch(() => {}).finally(() => client.disconnect(zmqEndpoint));
       return client;
     });
   }


### PR DESCRIPTION
I only tested this fix with the basic bot examples (the `$play-live` and `$stop-stream` commands)

stdout:
```
  ...
  INFO demux:format     "sample_rate": 48000
  INFO demux:format   }
  INFO demux:format } +21ms
An error happened with ffmpeg
Error: ffmpeg was killed with signal SIGTERM
    at ChildProcess.<anonymous> (C:\Users\<username>\Desktop\Discord-video-experiment\node_modules\fluent-ffmpeg\lib\processor.js:178:22)
    at ChildProcess.emit (node:events:508:28)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12)
  INFO demux:frame:common Reached end of stream. Stopping +0ms
 ```