### PR TITLE
Add `bufsize` to ffmpeg to limit bitrate spikes

### DIFF
--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -263,7 +263,7 @@ export function prepareStream(
       "-maxrate:v",
       `${bitrateVideoMax}k`,
       "-bufsize:v",
-      `${Math.round(bitrateVideo / 2)}k`,
+      `${Math.round(bitrateVideo / 6)}k`,
       "-bf",
       "0",
       "-pix_fmt",


### PR DESCRIPTION
Attempt to fix #201 by constraining bitrate more to prevent bitrate spikes at keyframes